### PR TITLE
Fixes #8 by using new built-in CS2D function

### DIFF
--- a/yates_functions.lua
+++ b/yates_functions.lua
@@ -926,12 +926,13 @@ end
 	@return table
 ]]
 function getDirectories(path)
-    local i, t, popen = 0, {}, io.popen
-    local pfile = popen('ls -a "'..path..'"')
-    for filename in pfile:lines() do
-        i = i + 1
-        t[i] = filename
-    end
-    pfile:close()
-    return t
+	local content = {}
+	
+	for name in io.enumdir(path) do
+		if name ~= "." and name ~= ".." then
+			content[ #content + 1 ] = name
+		end
+	end
+	
+	return content
 end


### PR DESCRIPTION
Changes getDirectories() code to use a new platform independent function io.enumdir() introduced in CS2D 1.0.0.2 update

Might introduce incompatibility issues with current code since it filters out "." and ".." entries that "ls -a" doesn't hide.

[Link to the changelog](http://unrealsoftware.de/forum_posts.php?post=402274)
