### PR TITLE
fix getPlayerGroupLevel

### DIFF
--- a/yates_functions.lua
+++ b/yates_functions.lua
@@ -1018,5 +1018,5 @@ function getPlayerGroupLevel(usgn)
 		end
 	end
 
-	return false
+	return return _GROUP.default.level
 end


### PR DESCRIPTION
Returns default level instead of false if usgn is not registered. This fixes comparing the bug if it the results are boolean.